### PR TITLE
Fix dbl quotes within dq string to typographic quotes

### DIFF
--- a/content/events/2020/linux_stammtisch_2020_01.md
+++ b/content/events/2020/linux_stammtisch_2020_01.md
@@ -2,7 +2,7 @@
 title: "Linux-Stammtisch Januar 2020"
 date: "2020-01-10"
 ical: 'linux-stammtisch'
-location: "Wirtshaus "Zur Altstadt", Elisabethstraße 16, 02826 Görlitz"
+location: "Wirtshaus „Zur Altstadt“, Elisabethstraße 16, 02826 Görlitz"
 startTime: "19:00"
 endTime: "21:30"
 ---


### PR DESCRIPTION
The usage of double quotes caused a parser error.